### PR TITLE
docs: add initial docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,62 +8,10 @@ Use this library for automatically adding a minimal set of ECS fields to your lo
 While we strive to comply to [semver](https://semver.org/), we can not guarantee to avoid breaking changes in minor releases.
 
 ---
- 
-The encoder logs in JSON format, relying on the default [logrus.JSONFormatter](https://pkg.go.dev/github.com/sirupsen/logrus#JSONFormatter) internally. 
 
-The following fields will be added by default:
-```
-{
-    "@timestamp":"1970-01-01T0000:00.000Z",
-    "ecs.version":"1.6.0",
-    "log.level":"info",
-    "message":"some logging info"
-}
-```
+## Documentation
 
-The formatter takes care of logging error fields in the [ECS error format](https://www.elastic.co/guide/en/ecs/current/ecs-error.html),
-and adding optional caller (file/function) information the [ECS log format](https://www.elastic.co/guide/en/ecs/current/ecs-log.html).
-Additional fields will be recorded as ECS "labels".
-
-## What is ECS?
-
-Elastic Common Schema (ECS) defines a common set of fields for ingesting data into Elasticsearch.
-For more information about ECS, visit the [ECS Reference Documentation](https://www.elastic.co/guide/en/ecs/current/ecs-reference.html).
-
-## Example usage
-
-### Set up a logger
-```go
-import (
-	"github.com/sirupsen/logrus"
-	"go.elastic.co/ecslogrus"
-)
-
-log := logrus.New()
-log.SetFormatter(&ecslogrus.Formatter{})
-```
-
-### Use structured logging
-```go
-epoch := time.Unix(0, 0).UTC()
-log.WithTime(epoch).WithField("custom", "foo").Info("hello")
-
-// Output:
-// {"@timestamp":"1970-01-01T00:00:00.000Z","custom":"foo","ecs.version":"1.6.0","log.level":"info","message":"hello"}
-```
-
-### Log errors
-```go
-epoch := time.Unix(0, 0).UTC()
-log.WithTime(epoch).WithError(errors.New("boom!")).Error("an error occurred")
-
-// Output:
-// {"@timestamp":"1970-01-01T00:00:00.000Z","ecs.version":"1.6.0","error":{"message":"boom!"},"log.level":"error","message":"an error occurred"}
-```
-
-## References
-* Introduction to ECS [blog post](https://www.elastic.co/blog/introducing-the-elastic-common-schema).
-* Logs UI [blog post](https://www.elastic.co/blog/infrastructure-and-logs-ui-new-ways-for-ops-to-interact-with-elasticsearch).
+Ready to get started? Documentation is at [elastic.co](https://www.elastic.co/guide/en/ecs-logging/go-logrus/current/index.html).
 
 ## Test
 ```

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,16 @@
+:ecs-repo-dir:  {ecs-logging-root}/docs/
+
+include::{docs-root}/shared/versions/stack/current.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
+
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/ecs-logging/go-logrus/current/index.html[elastic.co]
+endif::[]
+
+= ECS Logging Go Logrus Reference
+
+ifndef::env-github[]
+include::./introduction.asciidoc[Introduction]
+include::./setup.asciidoc[Set up]
+endif::[]

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -1,0 +1,29 @@
+[[intro]]
+== Introduction
+
+beta::[]
+
+ECS loggers are formatter/encoder plugins for your favorite logging libraries.
+They make it easy to format your logs into ECS-compatible JSON.
+
+The encoder logs in JSON format, relying on the default
+https://pkg.go.dev/github.com/sirupsen/logrus#JSONFormatter[logrus.JSONFormatter] internally.
+It also handles the logging of error fields in
+https://www.elastic.co/guide/en/ecs/current/ecs-error.html[ECS error format].
+
+By default, the following fields are added:
+
+[source,json]
+----
+{
+  "log.level": "info",
+  "@timestamp": "2020-09-13T10:48:03.000Z",
+  "message":" some logging info",
+  "ecs.version": "1.6.0"
+}
+----
+
+TIP: Want to learn more about ECS, ECS logging, and other available language plugins?
+See the {ecs-logging-ref}/intro.html[ECS logging guide].
+
+Ready to jump into `ecslogrus`? <<setup,Get started>>.

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -1,0 +1,121 @@
+[[setup]]
+== Get started
+
+[float]
+[[setup-step-1]]
+=== Step 1: Install
+
+Add the package to your `go.mod` file:
+
+[source,go]
+----
+require go.elastic.co/ecslogrus master
+----
+
+[float]
+[[setup-step-2]]
+=== Step 2: Configure
+
+Set up a default logger. For example:
+
+[source,go]
+----
+log := logrus.New()
+log.SetFormatter(&ecslogrus.Formatter{})
+----
+
+[float]
+[[examples]]
+=== Examples
+
+[float]
+[[use-structured-logging]]
+==== Use structured logging
+
+[source,go]
+----
+// Add custom fields.
+log.WithError(errors.New("boom!")).WithField("custom", "foo").Info("hello")
+----
+
+The example above produces the following log output:
+
+[source,json]
+----
+{
+  "@timestamp": "2021-01-20T11:12:43.061+0800",
+  "custom":"foo",
+  "ecs.version": "1.6.0",
+  "error": {
+    "message": "boom!"
+  },
+  "log.level": "info",
+  "message":"hello"
+}
+----
+
+[float]
+[[nest-data-labels]]
+==== Nest custom fields under "labels"
+
+For complete ECS compliance, custom fields should be nested in a "labels" object.
+
+[source,go]
+----
+log := logrus.New()
+log.SetFormatter(&ecslogrus.Formatter{
+    DataKey: "labels",
+})
+log.WithError(errors.New("boom!")).WithField("custom", "foo").Info("hello")
+----
+
+The example above produces the following log output:
+
+[source,json]
+----
+{
+  "@timestamp": "2021-01-20T11:12:43.061+0800",
+  "ecs.version": "1.6.0",
+  "error": {
+    "message": "boom!"
+  },
+  "labels": {
+    "custom": "foo"
+  },
+  "log.level": "info",
+  "message":"hello"
+}
+----
+
+[float]
+[[report-caller]]
+==== Report caller information
+
+[source,go]
+----
+log := logrus.New()
+log.SetFormatter(&ecslogrus.Formatter{})
+log.ReportCaller = true
+log.Info("hello")
+----
+
+The example above produces the following log output:
+
+[source,json]
+----
+{
+  "@timestamp": "2021-01-20T11:12:43.061+0800",
+  "ecs.version": "1.6.0",
+  "log.level": "info",
+  "log.origin.file.line": 48,
+  "log.origin.file.name": "/path/to/example_test.go",
+  "log.origin.function": "go.elastic.co/ecslogrus_test.ExampleFoo",
+  "message":"hello"
+}
+----
+
+[float]
+[[setup-step-3]]
+=== Step 3: Configure Filebeat
+
+include::{ecs-repo-dir}/setup.asciidoc[tag=configure-filebeat]


### PR DESCRIPTION
Significantly cribbed from ecszap, with the obvious bits replaced.

Required for #5 

Build locally with the following command:

```
$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-go-logrus/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1 --open
```