### PR TITLE
Add service.name to well-defined fields and allow configuration throu…

### DIFF
--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -115,6 +115,32 @@ The example above produces the following log output:
 ----
 
 [float]
+[[service-name]]
+==== Include service name
+
+[source,go]
+----
+log := logrus.New()
+log.SetFormatter(&ecslogrus.Formatter{
+    ServiceName: "my-service",
+})
+log.Info("hello")
+----
+
+The example above produces the following log output:
+
+[source,json]
+----
+{
+  "@timestamp": "2022-09-13T09:58:56.217+0200",
+  "ecs.version": "1.6.0",
+  "log.level": "info",
+  "message": "hello",
+  "service.name": "my-service"
+}
+----
+
+[float]
 [[setup-step-3]]
 === Step 3: Configure Filebeat
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.5.0
+	golang.org/x/sys v0.0.0-20211102192858-4dd72447c267 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.0 h1:DMOzIV76tmoDNE9pX6RSN0aDtCYeCg5VueieJaAo1uw=
 github.com/stretchr/testify v1.5.0/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20211102192858-4dd72447c267 h1:7zYaz3tjChtpayGDzu6H0hDAUM5zIGA2XW7kRNgQ0jc=
+golang.org/x/sys v0.0.0-20211102192858-4dd72447c267/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/magefile.go
+++ b/magefile.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build mage
 // +build mage
 
 package main


### PR DESCRIPTION
ECS 1.6.0 defines service.name as a configurable field to help filter logs by service. Additionally this field is used by kibana to display the name of the service logging an entry when correlating logs in distributed tracing. When using this formatter, adding service.name as a field on the log entry will add it within the nested custom fields.

This PR will enable the possibility of configuring formatter with a service name for all log entries and also overrides this value if entry.Data already contain a value for service.name.