### PR TITLE
synchronize ecs-logging spec

### DIFF
--- a/internal/spec/v1.json
+++ b/internal/spec/v1.json
@@ -9,7 +9,11 @@
             "type": "datetime",
             "required": true,
             "index": 0,
-            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html"
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html",
+            "comment": [
+                "Field order, as specified by 'index', is RECOMMENDED.",
+                "ECS loggers must implement field order unless the logging framework makes that impossible."
+            ]
         },
         "log.level": {
             "type": "string",
@@ -27,14 +31,23 @@
         },
         "message": {
             "type": "string",
-            "required": true,
+            "required": false,
             "index": 2,
-            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html"
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html",
+            "comment": [
+                "A message field is typically included in all log records, but some logging libraries allow records with no message.",
+                "That's typically the case for libraries that allow for structured logging."
+            ]
         },
         "ecs.version": {
             "type": "string",
             "required": true,
-            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-ecs.html"
+            "top_level_field": true,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-ecs.html",
+            "comment": [
+                "This field SHOULD NOT be a nested object field but at the top level with a dot in the property name.",
+                "This is to make the JSON logs more human-readable."
+            ]
         },
         "labels": {
             "type": "object",
@@ -65,24 +78,51 @@
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
             "comment": [
                 "Configurable by users.",
-                "When an APM agent is active, they should auto-configure it if not already set."
+                "When an APM agent is active, it should auto-configure this field if not already set."
+            ]
+        },
+        "service.node.name": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
+            "comment": [
+                "Configurable by users.",
+                "When an APM agent is active and `service_node_name` is manually configured, the agent should auto-configure this field if not already set."
+            ]
+        },
+        "service.version": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html#field-service-version",
+            "comment": [
+                "Configurable by users.",
+                "When an APM agent is active, it should auto-configure it if not already set."
             ]
         },
         "event.dataset": {
             "type": "string",
             "required": false,
             "url": "https://www.elastic.co/guide/en/ecs/current/ecs-event.html",
-            "default": "${service.name}.log OR ${service.name}.${appender.name}",
+            "default": "${service.name} OR ${service.name}.${appender.name}",
             "comment": [
                 "Configurable by users.",
                 "If the user manually configures the service name,",
-                "the logging library should set `event.dataset=${service.name}.log` if not explicitly configured otherwise.",
+                "the logging library should set `event.dataset=${service.name}` if not explicitly configured otherwise.",
                 "",
                 "When agents auto-configure the app to use an ECS logger,",
                 "they should set `event.dataset=${service.name}.${appender.name}` if the appender name is available in the logging library.",
-                "Otherwise, agents should also set `event.dataset=${service.name}.log`",
+                "Otherwise, agents should also set `event.dataset=${service.name}`",
                 "",
                 "The field helps to filter for different log streams from the same pod, for example and is required for log anomaly detection."
+            ]
+        },
+        "service.environment": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html#field-service-environment",
+            "comment": [
+                "Configurable by users.",
+                "When an APM agent is active, it should auto-configure it if not already set."
             ]
         },
         "process.thread.name": {


### PR DESCRIPTION
### What

ECS logging specs automatic sync

### Why

*Changeset*
* https://github.com/elastic/ecs-logging/commit/438fc2c Ensure ecs.version is treated as a top level field (https://github.com/elastic/ecs-logging/pull/71)